### PR TITLE
User serviceAccountName instead of serviceAccount

### DIFF
--- a/openshift/e2e-add-service-account.py
+++ b/openshift/e2e-add-service-account.py
@@ -10,5 +10,5 @@ import sys
 data = list(yaml.load_all(sys.stdin))
 for x in data:
     if x['kind'] in ('PipelineRun', 'TaskRun'):
-        x['spec']['serviceAccount'] = sys.argv[1]
+        x['spec']['serviceAccountName'] = sys.argv[1]
 print(yaml.dump_all(data, default_flow_style=False))


### PR DESCRIPTION
In the same spirit of https://github.com/tektoncd/pipeline/pull/1291 let use
serviceAccountName

/cc @vdemeester