### PR TITLE
Make sure pipelines-catalog branch match the tag for release

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -32,6 +32,11 @@ PIPELINES_CATALOG_DIRECTORY=./openshift/pipelines-catalog
 PIPELINES_CATALOG_IGNORE="s2i-dotnet-1"
 PIPELINES_CATALOG_PRIVILIGED_TASKS="s2i-*"
 
+CURRENT_TAG=$(git describe --tags 2>/dev/null || true)
+if [[ -n ${CURRENT_TAG} ]];then
+    PIPELINES_CATALOG_REF=origin/release-$(echo ${CURRENT_TAG}|sed -e 's/.*\(v[0-9]*\.[0-9]*\).*/\1/')
+fi
+
 # Add PIPELINES_CATALOG in here so we can do the CI all together.
 # We checkout the repo in ${PIPELINES_CATALOG_DIRECTORY}, merge them in the main
 # repos and launch the tests.
@@ -41,7 +46,7 @@ function pipelines_catalog() {
     local ptest parent
 
     [[ -d ${PIPELINES_CATALOG_DIRECTORY} ]] || \
-        git clone --depth=1 ${PIPELINES_CATALOG_URL} ${PIPELINES_CATALOG_DIRECTORY}
+        git clone ${PIPELINES_CATALOG_URL} ${PIPELINES_CATALOG_DIRECTORY}
 
     pushd ${PIPELINES_CATALOG_DIRECTORY} >/dev/null && \
         git reset --hard ${PIPELINES_CATALOG_REF} &&


### PR DESCRIPTION
We were always testing against origin/master but when we do a released version
we should test against that released version instead of master.

/hold
/cc @sthaha @nikhilthomas


<!-- 🎉🎉🎉 Thank you for the PR!!! This is the Downstream Catalog repository, only used for downstream `stuff` and CI, all the other `stuff` goes upstream. 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```