### PR TITLE
Skip the dotnet3 e2e

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -29,7 +29,8 @@ SERVICE_ACCOUNT=builder
 PIPELINES_CATALOG_URL=https://github.com/openshift/pipelines-catalog/
 PIPELINES_CATALOG_REF=origin/master
 PIPELINES_CATALOG_DIRECTORY=./openshift/pipelines-catalog
-PIPELINES_CATALOG_IGNORE="s2i-dotnet-1"
+# We are skipping e2e test for dotnet3 as the builder image is not publicly available yet
+PIPELINES_CATALOG_IGNORE="s2i-dotnet-3"
 PIPELINES_CATALOG_PRIVILIGED_TASKS="s2i-*"
 
 CURRENT_TAG=$(git describe --tags 2>/dev/null || true)


### PR DESCRIPTION
This will skip the dotnet3 e2e test as the image is
not publicly available yet

Also enable dotnet1 as the e2e is working now

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
release-note
```
