### PR TITLE
Modify Update-to-head.sh

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -21,8 +21,8 @@ echo "===== Resetting branch ${release} based on ${tag}"
 # Fetch the latest tags and checkout a new branch from the wanted tag.
 git fetch upstream --tags
 
-echo "===== Checkout upstream/master as base"
-git checkout --no-track -B "${release}" upstream/master
+echo "===== Checkout upstream/v1beta1 as base"
+git checkout --no-track -B "${release}" upstream/v1beta1
 
 echo "===== Adding openshift specific files from openshift/master"
 git fetch openshift master

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -6,9 +6,9 @@
 set -e
 REPO_NAME=`basename $(git rev-parse --show-toplevel)`
 
-# Reset release-next to upstream/master.
-git fetch upstream master
-git checkout upstream/master --no-track -B release-next
+# Reset release-next to upstream/v1beta1.
+git fetch upstream v1beta1
+git checkout upstream/v1beta1 --no-track -B release-next
 
 # Update openshift's master and take all needed files from there.
 git fetch openshift master


### PR DESCRIPTION
Sync to upstream/v1beta1 instead of upstream/master
in nightly and in release branches

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! This is the Downstream Catalog repository, only used for downstream `stuff` and CI, all the other `stuff` goes upstream. 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
