### PR TITLE
Use v1beta1 for catalog

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -5,10 +5,11 @@
 
 set -e
 REPO_NAME=`basename $(git rev-parse --show-toplevel)`
+BRANCH=${BRANCH:-v1beta1}
 
 # Reset release-next to upstream/master.
 git fetch upstream master
-git checkout upstream/master --no-track -B release-next
+git checkout upstream/${BRANCH} --no-track -B release-next
 
 # Update openshift's master and take all needed files from there.
 git fetch openshift master


### PR DESCRIPTION
Use v1beta1 by default for nightly CI

<!-- 🎉🎉🎉 Thank you for the PR!!! This is the Downstream Catalog repository, only used for downstream `stuff` and CI, all the other `stuff` goes upstream. 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```