### PR TITLE
Fix Release-v0.11 README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,4 @@
-# Tekton Catalog (v1alpha1)
-
-**This contains tektoncd/pipeline resources for the `v1alpha1`
-API. This branch is kept around for the time tektoncd/pipeline will
-continue supporting `v1alpha1` APIs. It is meant to be a *fix-only*
-branch, any new Task should be added to the `v1beta1` branch**
+# Tekton Catalog
 
 **If you want `v1alpha1` resources, you need to go to the
 [`master`](https://github.com/tektoncd/catalog/tree/master) branch (or


### PR DESCRIPTION
nit: the Readme Title is (Tekton Catalog (v1alpha1))
This might confuse our users.

all the Tasks are merged correctly :thumbsup: 
[i did a diff branch (openshift/release-v0.11..upstream/v1beta1) (v1beta1=276aef3)]
diff: https://pastebin.com/Et1Ph3CY

This patch will make the README.md same as `upstream/v1beta1` README.md

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! This is the Downstream Catalog repository, only used for downstream `stuff` and CI, all the other `stuff` goes upstream. 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
