### PR TITLE
Fix syncing code from upstream

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -21,10 +21,10 @@ echo "===== Resetting branch ${release} based on ${tag}"
 # Fetch the latest tags and checkout a new branch from the wanted tag.
 git fetch upstream --tags
 
-echo "===== Checkout upstream/v1beta1 as base"
-git checkout --no-track -B "${release}" upstream/v1beta1
+echo "===== Checkout upstream/master as base"
+git checkout --no-track -B "${release}" upstream/master
 
-echo "===== Adding openshift specific files from openshift/v1beta1"
+echo "===== Adding openshift specific files from openshift/master"
 git fetch openshift master
 git checkout openshift/master -- openshift OWNERS_ALIASES OWNERS
 

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -5,11 +5,11 @@
 
 set -e
 REPO_NAME=`basename $(git rev-parse --show-toplevel)`
-BRANCH=${BRANCH:-v1beta1}
+BRANCH=${BRANCH:-master}
 OPENSHIFT_REMOTE=${OPENSHIFT_REMOTE:-openshift}
 
-# Reset release-next to upstream/v1beta1.
-git fetch upstream v1beta1
+# Reset release-next to upstream/master.
+git fetch upstream ${BRANCH}
 git checkout upstream/${BRANCH} --no-track -B release-next
 
 # Update openshift's master and take all needed files from there.


### PR DESCRIPTION
This will fix syncing code from upstream as the upstream
default branch has been changed to master and
midstream is still syncing from v1beta1 branch, it will
fix that to sync from upstream master now

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Fix syncing code from upstream
```
