### PR TITLE
Skip newly added dotnet3 test

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -30,7 +30,7 @@ PIPELINES_CATALOG_URL=${PIPELINES_CATALOG_URL:-https://github.com/openshift/pipe
 PIPELINES_CATALOG_REF=${PIPELINES_CATALOG_REF:-origin/master}
 PIPELINES_CATALOG_DIRECTORY=./openshift/pipelines-catalog
 # We are skipping e2e test for dotnet3 as the builder image is not publicly available yet
-PIPELINES_CATALOG_IGNORE="s2i-dotnet-3"
+PIPELINES_CATALOG_IGNORE="s2i-dotnet-3 s2i-dotnet-3-pr"
 PIPELINES_CATALOG_PRIVILIGED_TASKS="s2i-*"
 
 CURRENT_TAG=$(git describe --tags 2>/dev/null || true)


### PR DESCRIPTION
Because of refactoring in pipelines catalog, one new task added
for dotnet3 workspace based. as the image is not publicly available
we need to skip both the test

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
