### PR TITLE
Wrap test_yaml_can_install in a retry loop

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -101,7 +101,12 @@ function in_array() {
 pipelines_catalog
 
 # Test if yamls can install
-test_yaml_can_install
+until test_yaml_can_install; do
+  echo "-----------------------"
+  echo 'retry test_yaml_can_install'
+  echo "-----------------------"
+  sleep 5
+done
 
 # Run the privileged tests
 for runtest in ${PRIVILEGED_TESTS};do


### PR DESCRIPTION
This should fix the recurring ci fails because of the
`webhook endpoints not found` error.

This worked in a test pr
https://github.com/openshift/tektoncd-catalog/pull/303

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! This is the Downstream Catalog repository, only used for downstream `stuff` and CI, all the other `stuff` goes upstream. 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
