### PR TITLE
Update openssl to version 1.1.1g

### DIFF
--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -1,17 +1,26 @@
 FROM openshift/origin-release:golang-1.13
 
 # download, verify and install openshift client tools (oc and kubectl)
+# upgrade the openssl to the recent version ie 1.1.1g
 WORKDIR /tmp
 RUN OPENSHIFT_CLIENT_VERSION=$(curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/release.txt|sed -n '/Version:/ { s/[ ]*Version:[ ]*// ;p}') \
     && curl -L -O -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OPENSHIFT_CLIENT_VERSION/openshift-client-linux-$OPENSHIFT_CLIENT_VERSION.tar.gz \
+    && curl -LO https://www.openssl.org/source/openssl-1.1.1g.tar.gz \
     && curl -L -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OPENSHIFT_CLIENT_VERSION/sha256sum.txt | \
        grep openshift-client-linux-$OPENSHIFT_CLIENT_VERSION.tar.gz > openshift-origin-client-tools.sha256 \
     && sha256sum -c openshift-origin-client-tools.sha256 \
     && mkdir openshift-origin-client-tools \
     && tar xzf openshift-client-linux-$OPENSHIFT_CLIENT_VERSION.tar.gz --directory openshift-origin-client-tools \
+    && tar xf openssl-1.1.1g.tar.gz \
     && mv /tmp/openshift-origin-client-tools/oc /usr/bin/oc \
     && mv /tmp/openshift-origin-client-tools/kubectl /usr/bin/kubectl \
     && rm -rf ./openshift* \
+    && cd openssl-1.1.1g \
+    && ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl enable-ec_nistp_64_gcc_128 no-ssl2 no-ssl3 no-comp no-idea no-dtls no-dtls1 no-shared no-psk no-srp no-ec2m no-weak-ssl-ciphers \
+    && make install \
+    && cd .. \
+    && rm -rf openssl-1.1.1g.tar.gz openssl-1.1.1g \
+    && mv /usr/local/ssl/bin/openssl /usr/local/bin/openssl \
     && oc version
 
 # upgrade to latest PyYAML


### PR DESCRIPTION
# Changes

The Dockerfile by default was using an older version of openssl ie
`OpenSSL 1.0.2k-fips  26 Jan 2017` whereas the latest version is
`OpenSSL 1.1.1g  21 Apr 2020` and also tests in buildah latest version
requires latest version of openssl so bumping the version of openssl.

/cc @piyush-garg @chmouel @pradeepitm12 @vdemeester 

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
