### PR TITLE
Fix 352

### DIFF
--- a/openshift/e2e-add-service-account.py
+++ b/openshift/e2e-add-service-account.py
@@ -9,6 +9,8 @@ import yaml
 import sys
 data = list(yaml.safe_load_all(sys.stdin))
 for x in data:
+    if not x:
+        continue
     if x['kind'] in ('PipelineRun', 'TaskRun'):
         x['spec']['serviceAccountName'] = sys.argv[1]
 print(yaml.dump_all(data, default_flow_style=False))


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! This is the Downstream Catalog repository, only used for downstream `stuff` and CI, all the other `stuff` goes upstream. 🎉🎉🎉 -->

# Changes

* Added more checks(`check-for-pipelines-deployment-availability`) to ensure pipelines installation is proper, before we actually start our tests, as we are seeing failures frequently on 4.6 cluster, webhook pod  wasn't available at the time when start our test.
* Update `e2e-add-service-account.py` script to ignore `typeerror` when user provides `test/run.yaml`  with `---` at the end of file (empty document).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
