### PR TITLE
Add a check for an existing sync PR in the midstream repo

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -5,6 +5,8 @@
 
 set -e
 REPO_NAME=$(basename $(git rev-parse --show-toplevel))
+BRANCH=${BRANCH:-main}
+OPENSHIFT_REMOTE=${OPENSHIFT_REMOTE:-openshift}
 
 # Reset release-next to upstream/master.
 git fetch upstream master

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -4,7 +4,7 @@
 # Usage: update-to-head.sh
 
 set -e
-REPO_NAME=`basename $(git rev-parse --show-toplevel)`
+REPO_NAME=$(basename $(git rev-parse --show-toplevel))
 
 # Reset release-next to upstream/master.
 git fetch upstream master
@@ -26,7 +26,12 @@ git commit -m ":robot: Triggering CI on branch 'release-next' after synching to 
 git push -f openshift release-next-ci
 
 if hash hub 2>/dev/null; then
-   hub pull-request --no-edit -l "kind/sync-fork-to-upstream" -b openshift/${REPO_NAME}:release-next -h openshift/${REPO_NAME}:release-next-ci
+   # Test if there is already a sync PR in 
+   COUNT=$(hub api -H "Accept: application/vnd.github.v3+json" repos/openshift/${REPO_NAME}/pulls --flat \
+    | grep -c ":robot: Triggering CI on branch 'release-next' after synching to upstream/ma") || true
+   if [ "$COUNT" = "0" ]; then
+      hub pull-request --no-edit -l "kind/sync-fork-to-upstream" -b openshift/${REPO_NAME}:release-next -h openshift/${REPO_NAME}:release-next-ci
+   fi
 else
    echo "hub (https://github.com/github/hub) is not installed, so you'll need to create a PR manually."
 fi


### PR DESCRIPTION
# Changes

This will allow the Jenkins jobs to use the actual return value of the
script, instead of grepping through the output.