### PR TITLE
Modified update-to-head.sh, nightly-ci-run.yaml and cron-nightly-ci-run.yaml to run on our qe cluster

### DIFF
--- a/openshift/release/cron-nightly-ci-run.yaml
+++ b/openshift/release/cron-nightly-ci-run.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: pipelines-catalog-nightly-ci-run
+spec:
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 1
+  concurrencyPolicy: Replace
+  schedule: "0 0 * * *"
+  startingDeadlineSeconds: 200
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: nightly-ci-sa
+          containers:
+            - name: cleanup
+              image: quay.io/openshift/origin-cli:4.6
+              command: ["/bin/bash", "-c", "kubectl delete pipelinerun pipelines-catalog-nightly || true;kubectl create -f https://raw.githubusercontent.com/openshift/tektoncd-catalog/master/openshift/release/nightly-ci-run.yaml"]
+          restartPolicy: Never

--- a/openshift/release/nightly-ci-run.yaml
+++ b/openshift/release/nightly-ci-run.yaml
@@ -60,6 +60,36 @@ spec:
                 set -x
                 # Launch script
                 openshift/release/update-to-head.sh
+    finally:
+      - name: finally
+        taskSpec:
+          steps:
+            - name: send-to-slack
+              env:
+                - name: SLACK_WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: slack-tektoncd-operator-ci-webhook
+                      key: hook_url
+                - name: PIPELINERUN
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.labels['tekton.dev/pipelineRun']
+                - name: LABEL_TO_CHECK
+                  value: "nightly-ci"
+                - name: SUCCESS_URL_ICON
+                  value: "https://github.com/tektoncd.png"
+                - name: FAILURE_URL_ICON
+                  value: "https://user-images.githubusercontent.com/4288561/114842214-eecf6c80-9dd8-11eb-8924-86288b1a501c.jpeg"
+                - name: SUCCESS_SUBJECT
+                  value: "Tektoncd catalog CI nightly sync with upstream ran successfully  :pipelines: :dance_cat: :yay2:"
+                - name: FAILURE_SUBJECT
+                  value: "Tektoncd catalog CI nightly sync with upstream has failed :pipeline: :sadparrot: :failed:"
+                - name: LOG_URL
+                  value: "https://console-openshift-console.apps.cicd.tekton.codereadyqe.com/k8s/ns/nightly-ci/tekton.dev~v1beta1~PipelineRun/pipelines-catalog-nightly"
+
+              image: quay.io/chmouel/tekton-asa-code:latest
+              command: [ "/code/misc/send-slack-notifications.py" ]
   workspaces:
     - name: source
       volumeClaimTemplate:

--- a/openshift/release/nightly-ci-run.yaml
+++ b/openshift/release/nightly-ci-run.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pipelines-catalog-nightly
+spec:
+  pipelineSpec:
+    workspaces:
+      - name: source
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: source
+        params:
+          - name: url
+            value: https://github.com/openshift/tektoncd-catalog
+          - name: revision
+            value: master
+          - name: subdirectory
+            value: ""
+          - name: deleteExisting
+            value: "true"
+      - name: create-pr
+        runAfter:
+          - fetch-repository
+        workspaces:
+          - workspace: source
+            name: source
+        taskSpec:
+          workspaces:
+            - name: source
+          steps:
+            - name: create-pr
+              workingDir: $(workspaces.source.path)
+              env:
+                - name: HUB_VERSION
+                  value: "true"
+                - name: GITHUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: nightly-ci-github-hub-token
+                      key: hub-token
+              image: gcr.io/tekton-releases/dogfooding/hub:latest
+              script: |
+                #!/usr/bin/env bash
+                set -xe
+                apk add make || true # add this true or remove -x from this script
+                apk add gettext || true # add this true or remove -x from this script
+                # Configure git email and name
+                git config user.email "pipelines-dev@redhat.com"
+                git config user.name "OpenShift Pipelines"
+
+                ## Make sure we can push to the branch with our GITHUB_TOKEN (disable logging to not leak)
+                set +x
+                git remote add upstream $(echo "https://github.com/tektoncd/catalog.git"|sed "s,https://github.com/,https://${GITHUB_TOKEN}@github.com/,")
+                git remote add openshift $(echo "https://github.com/openshift/tektoncd-catalog.git"|sed "s,https://github.com/,https://${GITHUB_TOKEN}@github.com/,")
+                set -x
+                # Launch script
+                openshift/release/update-to-head.sh
+  workspaces:
+    - name: source
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 500Mi

--- a/openshift/release/nightly-ci-run.yaml
+++ b/openshift/release/nightly-ci-run.yaml
@@ -23,7 +23,7 @@ spec:
             value: ""
           - name: deleteExisting
             value: "true"
-      - name: create-pr
+      - name: sync-upstream-to-midstream
         runAfter:
           - fetch-repository
         workspaces:
@@ -33,7 +33,7 @@ spec:
           workspaces:
             - name: source
           steps:
-            - name: create-pr
+            - name: sync-upstream-to-midstream
               workingDir: $(workspaces.source.path)
               env:
                 - name: HUB_VERSION

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -20,23 +20,3 @@ git add openshift OWNERS_ALIASES OWNERS
 git commit -m ":open_file_folder: Update openshift specific files."
 
 git push -f ${OPENSHIFT_REMOTE} HEAD:release-next
-
-# Trigger CI
-git checkout release-next --no-track -B release-next-ci
-date > ci
-git add ci
-git commit -m ":robot: Triggering CI on branch 'release-next' after synching to upstream/main"
-git push -f ${OPENSHIFT_REMOTE} HEAD:release-next-ci
-
-# removing upstream remote so that hub points origin for hub pr list command due to this issue https://github.com/github/hub/issues/1973
-git remote remove upstream
-
-already_open_github_issue_id=$(hub pr list -s open -f "%I %l%n"|grep ${LABEL}| awk '{print $1}'|head -1)
-[[ -n ${already_open_github_issue_id} ]]  && {
-    echo "PR for nightly is already open on #${already_open_github_issue_id}"
-    #hub api repos/${OPENSHIFT_ORG}/${REPO_NAME}/issues/${already_open_github_issue_id}/comments -f body='/retest'
-    exit 0
-}
-
-hub pull-request -m "🛑🔥 Triggering Nightly CI for ${REPO_NAME} 🔥🛑" -m "/hold" -m "Nightly CI do not merge :stop_sign:" \
-    --no-edit -l "${LABEL}" -b ${OPENSHIFT_REMOTE}/${REPO_NAME}:release-next -h ${OPENSHIFT_REMOTE}/${REPO_NAME}:release-next-ci


### PR DESCRIPTION
1. modified update-to-head script to keep in sync with the operator one
2. Adding pipelinerun.yaml and cron.yaml, which will execute the pipelinerun
